### PR TITLE
Remove ontherunvaro OTA uri

### DIFF
--- a/system.prop
+++ b/system.prop
@@ -1,6 +1,3 @@
-#OTA
-cm.updater.uri=http://ota.ontherunvaro.com/api
-
 # Audio
 audio.dolby.ds2.enabled=true
 audio.offload.buffer.size.kb=64


### PR DESCRIPTION
As specified in commit https://github.com/ontherunvaro/android_device_tcl_q39/commit/175441422a9b355c8a1b94bcdea4e465253bfafa, the OTA url for my server is no good for you now and creates unneeded traffic there.

Cheers!